### PR TITLE
Add support for Scala 2.13 and drop support for Scala 2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,9 @@ val scalaconfig = project
     organization := "com.github.andr83",
     name := "scalaconfig",
     version := "0.6-SNAPSHOT",
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.13.3",
     scalacOptions += "-Xlog-implicits",
-    crossScalaVersions := Seq("2.10.6", "2.11.0", "2.12.0"),
+    crossScalaVersions := Seq("2.11.12", "2.12.12", "2.13.3"),
     isSnapshot := version.value.endsWith("-SNAPSHOT"),
     scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8"),
     resolvers ++= Seq(
@@ -35,10 +35,22 @@ val scalaconfig = project
     pomIncludeRepository := { _ => false },
     libraryDependencies ++= Seq(
       Library.typesafeConfig % "provided",
+      Library.scalaCollectionCompat,
       Library.scalaTest % "test",
-      Library.shapeless,
-      compilerPlugin(Library.scalaMacrosParadise cross CrossVersion.full)
+      Library.shapeless
     ),
+    Compile / scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n >= 13 => "-Ymacro-annotations" :: Nil
+        case _ => Nil
+      }
+    },
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n >= 13 => Nil
+        case _ => compilerPlugin(Library.scalaMacrosParadise cross CrossVersion.full) :: Nil
+      }
+    },
     pomExtra := {
       <url>https://github.com/andr83/scalaconfig</url>
       <licenses>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,15 +2,17 @@ import sbt._
 
 
 object Version {
-  val typesafeConfig = "1.3.1"
-  val scalaTest = "3.0.1"
-  val shapeless = "2.3.2"
-  val scalaMacrosParadise = "2.1.0"
+  val typesafeConfig = "1.4.0"
+  val scalaCollectionCompat = "2.1.6"
+  val scalaTest = "3.2.0"
+  val shapeless = "2.3.3"
+  val scalaMacrosParadise = "2.1.1"
 }
 
 object Library {
   val typesafeConfig = "com.typesafe" % "config" % Version.typesafeConfig
   val scalaTest = "org.scalatest" %% "scalatest" % Version.scalaTest
   val shapeless = "com.chuusai" %% "shapeless" % Version.shapeless
+  val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % Version.scalaCollectionCompat
   val scalaMacrosParadise = "org.scalamacros" % "paradise" % Version.scalaMacrosParadise
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.4
+sbt.version = 1.3.13

--- a/src/test/scala/com/github/andr83/scalaconfig/ReaderSpec.scala
+++ b/src/test/scala/com/github/andr83/scalaconfig/ReaderSpec.scala
@@ -3,14 +3,16 @@ package com.github.andr83.scalaconfig
 import java.util.Properties
 
 import com.typesafe.config.{Config, ConfigFactory, ConfigValue, ConfigValueType}
-import org.scalatest.{FlatSpec, Inside, Matchers}
+import org.scalatest.Inside
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
 /**
   * @author andr83
   */
-class ReaderSpec extends FlatSpec with Matchers with Inside {
+class ReaderSpec extends AnyFlatSpec with Matchers with Inside {
 
   "String value reader" should "read string" in {
     val config = ConfigFactory.parseString(s"stringField = SomeString")
@@ -21,7 +23,7 @@ class ReaderSpec extends FlatSpec with Matchers with Inside {
   "String value" should "be read as symbol also" in {
     val config = ConfigFactory.parseString(s"stringField = SomeString")
 
-    config.asUnsafe[Symbol]("stringField") should equal('SomeString)
+    config.asUnsafe[Symbol]("stringField") should equal(Symbol("SomeString"))
   }
 
   "Int value reader" should "read int" in {


### PR DESCRIPTION
Minimal changes to support Scala 2.13. I had to drop Scala 2.10 because there is no scala-collection-compat for it.